### PR TITLE
[codex] Align Codex environment guidance

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -172,8 +172,9 @@ the direction gate** (the look is already decided). The four:
         reference images / a logo / mood material**. Then **tailor the chosen style** to the
         scenario + brand before generating (the preset is a starting language, not a straitjacket).
      2. **Generate the template** — a **text-free** full-bleed hero/divider illustration in that
-        style with a calm zone for the title (**no API key needed** — auto-detect: native imagegen in
-        Codex → else the **Codex CLI** `scripts/generate_images_codex.py` if `codex` is installed →
+        style with a calm zone for the title (**no API key needed** — in Codex, use the native
+        imagegen tool call directly and save/copy the selected bitmap into the deck folder; outside a
+        native-imagegen host, fall back to the **Codex CLI** `scripts/generate_images_codex.py` if `codex` is installed →
         OpenAI `scripts/generate_images_openai.py` only as a fallback; see
         `references/image-generation.md`), then **derive a matching `style.py`**: pull the
         palette straight from the image with `deckkit.palette_from_image(...)` and define the
@@ -640,7 +641,8 @@ A few rules that matter (see `references/design-principles.md`):
   one-off generated *header* on a single body slide** (title chrome is `title_bar`'s; a content plate
   goes full-bleed / side-panel / inline, with one role+art-direction across the plated slides). Build prompts with
   `scripts/image_prompts.py` (a sub-outline of *only* the plated slides), then generate by the
-  **auto-detected** source — **no API key needed**: native imagegen (Codex) → else the **Codex CLI**
+  **auto-detected** source — **no API key needed**: native imagegen (Codex tool call, then save/copy
+  the bitmap into the deck folder) → else the **Codex CLI**
   `generate_images_codex.py` if `codex` is installed (no key) → OpenAI `generate_images_openai.py`
   (+`OPENAI_API_KEY`) only as a fallback if neither exists. Use what's present and say so; ask only if
   none is available (see `image-generation.md`); keep
@@ -759,6 +761,10 @@ slide). python-pptx writes blind — overflow, low contrast, a callout on the fo
 or a missing glyph only show up in the image. Fix mechanical issues and re-render.
 (First time on a machine, or a render errors? `bash scripts/check_env.sh` verifies
 LibreOffice + the python deps and prints the fix for anything missing.)
+**Codex sandbox note:** LibreOffice may abort or produce no PDF when launched inside a managed
+sandbox even though `check_env.py` passes; in that case rerun only the render command with elevated /
+unsandboxed execution, then continue the normal render -> lint -> critic loop. This is an environment
+permission issue, not evidence that the deck is malformed.
 
 **Then run the layout lint** — `python scripts/lint_deck.py <deck.pptx>` — a cheap, deterministic
 check that flags **off-slide overflow, text overflowing the card behind it, uneven card heights in a
@@ -1007,7 +1013,7 @@ A checkable red-flag list; if a draft does any of these, stop and fix it before 
 - `scripts/image_prompts.py` — create text-free image generation prompt manifests and
   expected filenames for optional slide visual plates.
 - `scripts/generate_images_codex.py` — **no-API-key** image generation (the default outside a
-  native-imagegen host): shells out to `codex exec` (the hosted `image_generation` tool), decodes the
+  native-imagegen host; inside Codex, prefer the native imagegen tool call): shells out to `codex exec` (the hosted `image_generation` tool), decodes the
   image from the Codex session rollout, and writes the manifest's `slide-XX.png` files. Auto-detected
   when `codex` is installed/logged-in; prompts are passed verbatim. **No key, no per-image cost.**
 - `scripts/generate_images_openai.py` — **fallback** OpenAI Images API path (only when neither native

--- a/references/generated-template.md
+++ b/references/generated-template.md
@@ -56,7 +56,8 @@ preset + a reference) is fine — just name what you're combining so the choice 
 Generate a **full-bleed, text-free** hero/divider illustration in the chosen style:
 - **Tooling — auto-detect the source, no API key needed** (build the prompt with
   `scripts/image_prompts.py`; full guidance in `references/image-generation.md`). Use what's present,
-  in order: **(1)** native imagegen when the host has it (inside Codex — free, no key); **(2)** else
+  in order: **(1)** native imagegen when the host has it (inside Codex — use the agent tool call
+  directly, free, no key); **(2)** else
   the **Codex CLI** `scripts/generate_images_codex.py --orientation landscape` if `codex` is installed
   (Codex/ChatGPT subscription, **no key** — shells `codex exec`, decodes the hosted image from the
   session rollout); **(3)** else, only as a fallback, the OpenAI API `scripts/generate_images_openai.py`

--- a/references/image-generation.md
+++ b/references/image-generation.md
@@ -170,7 +170,10 @@ common cases image generation needs **no API key**. **Detect what's available, u
 which — don't prompt the user to choose a path, and don't ask for a key by default.** Preference order:
 
 **1 · Native host imagegen** — if the host's agent has a built-in image tool (e.g. running *inside
-Codex*), generate directly with it. No key, no extra step.
+Codex*), generate directly with that tool call. No key, no extra step. In Codex specifically this is
+an agent tool, not a shell command a script can auto-detect; call it for each approved prompt, then
+save/copy the selected bitmap into `~/Downloads/<deck>/assets/generated/` before the build script
+references it.
 
 **2 · Codex CLI** — the default outside a native-imagegen host (e.g. in Claude Code): if the `codex`
 CLI is installed and logged in (check `which codex`; `codex login` once), shell out to it — it calls
@@ -196,8 +199,8 @@ python scripts/generate_images_openai.py \
 Both scripts share the manifest format and the `--out-dir` / `--limit` / `--overwrite` / `--dry-run`
 flags, save each output to the manifest path (e.g. `slide-01.png`), and skip existing files by default.
 
-> **Detection-first; ask only when stuck.** Pick native → Codex CLI → API key by what's installed,
-> proceed, and tell the user which you used (one line). **Only ask** when *none* is available — then
+> **Detection-first; ask only when stuck.** Pick native tool call → Codex CLI → API key by what's
+> available, proceed, and tell the user which you used (one line). **Only ask** when *none* is available — then
 > point them to `codex login` (no key) or, as a last resort, an `OPENAI_API_KEY`. Never block on a
 > choice when a working path is already present.
 

--- a/scripts/generate_images_codex.py
+++ b/scripts/generate_images_codex.py
@@ -137,7 +137,15 @@ def main():
               "scripts/generate_images_openai.py with OPENAI_API_KEY instead.", file=sys.stderr)
         return 2
 
-    items = json.loads(Path(args.manifest).read_text(encoding="utf-8"))
+    manifest = Path(args.manifest)
+    if not manifest.is_file():
+        print(f"error: manifest not found: {manifest}", file=sys.stderr)
+        return 2
+    try:
+        items = json.loads(manifest.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        print(f"error: invalid JSON in manifest {manifest}: {exc}", file=sys.stderr)
+        return 2
     if not isinstance(items, list):
         print("error: manifest must be a JSON list", file=sys.stderr)
         return 2


### PR DESCRIPTION
## Summary

- Clarify that native image generation inside Codex is an agent tool call, not a shell-detectable script path.
- Add a Codex sandbox note for LibreOffice rendering failures that occur despite a passing environment check.
- Make generate_images_codex.py return clean CLI errors for missing or malformed manifests.

## Validation

- PYTHONPYCACHEPREFIX=/private/tmp/slide-maker-repo-pyc python3 -m compileall -q /private/tmp/slides_maker_latest/scripts
- python3 /private/tmp/slides_maker_latest/scripts/generate_images_codex.py /no/such/manifest.json --dry-run
- python3 /private/tmp/slides_maker_latest/scripts/smoke_deckkit.py

Note: local gh auth status reports an invalid token.