### PR TITLE
Catch three shipped-text defect classes before the render loop

### DIFF
--- a/skills/slide-maker/scripts/deckkit.py
+++ b/skills/slide-maker/scripts/deckkit.py
@@ -548,6 +548,19 @@ def text(slide, x, y, w, h, runs, align=PP_ALIGN.LEFT, anchor=MSO_ANCHOR.TOP,
     AND give this textbox the SAME (x, y, w, h) as the box. A y-offset (e.g. y+0.07) combined
     with the box's full height pushes the centre below the box's true middle — text then reads
     "a bit low". Want top padding? Use margin_top, not a y-offset with unchanged height."""
+    if w <= 0 or h <= 0:
+        # A derived box can collapse to zero or NEGATIVE size when the arithmetic that sized
+        # it is wrong — `h = card_h - 1.42` with card_h = 1.30 gives -0.12. python-pptx accepts
+        # that silently, the run then overflows a box with no interior, and every geometry
+        # check stays green because there is nothing to overlap. Measured: it shipped a tier
+        # card whose body text spilled straight through the rule below it, and the defect
+        # survived to the render loop. Fail at the call instead: the traceback names the
+        # slide function, which is where the bad arithmetic lives.
+        raise ValueError(
+            f"text(): non-positive box {w:.3f}x{h:.3f}in at ({x:.2f}, {y:.2f}) — the size was "
+            f"derived from arithmetic that came out <= 0. Reserve the fixed elements first, "
+            f"then derive this box from what is LEFT (see SKILL.md 'never hand-pick a y')."
+        )
     tb = slide.shapes.add_textbox(Inches(x), Inches(y), Inches(w), Inches(h))
     tf = tb.text_frame
     tf.word_wrap = bool(wrap)

--- a/skills/slide-maker/scripts/palette_audit.py
+++ b/skills/slide-maker/scripts/palette_audit.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Resolve a deck's palette into FILL-only vs TEXT-safe tokens — once, before the build.
+
+WHY THIS EXISTS. SKILL.md already states the rule: "a hue used as TEXT must itself clear >=4.5:1
+on its background", so keep two tokens per accent — a bright fill and a darker text-safe twin.
+The rule is correct and it is still easy to break, because the check is per-PAIR and a build
+touches dozens of pairs. Measured on one real deck, the author declared the two-token rule in
+the design plan and then violated it four separate times — a vivid ochre set as a tier label on
+its own pale slab (2.34:1), coral emphasis text on a coral tint (4.19:1), a table's highlight
+colour (4.19:1), and a muted grey used for real content on cream (4.26:1). None were reckless;
+each was a pair the author simply was not thinking about while computing contrast ad-hoc for a
+different pair. Every one surfaced at render time or in review, each costing a round.
+
+A matrix is the fix. Computing all N x M pairs once costs nothing and turns "I remembered to
+darken the coral" into a table you read. Print it at Step 2/3, paste the FILL/TEXT split into
+the design plan, and build from the tokens it hands back.
+
+    # explicit tokens
+    python3 scripts/palette_audit.py --inks E2543A,D18A2E,1F5F63,20304A \\
+                                     --grounds FAF3E4,FBE3DC,F7E7CE,FFFFFF
+
+    # or pull every colour constant out of a deck's style module
+    python3 scripts/palette_audit.py --from-style ~/Downloads/mydeck/style.py
+
+Thresholds are WCAG: 4.5 body text · 3.0 large text (>=18pt, or >=14pt bold) · 3.0 non-text
+marks (icon glyph on its tile, a symbol on a chip, an arrowhead on a band — WCAG 1.4.11).
+
+Exit 0 when every pair the deck actually needs is resolvable, 1 when a token has no safe use.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import sys
+from pathlib import Path
+
+BODY, LARGE, MARK = 4.5, 3.0, 3.0
+
+
+def _srgb(c: float) -> float:
+    c /= 255.0
+    return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+
+def _lum(hexs: str) -> float:
+    h = hexs.lstrip("#")
+    r, g, b = (int(h[i:i + 2], 16) for i in (0, 2, 4))
+    return 0.2126 * _srgb(r) + 0.7152 * _srgb(g) + 0.0722 * _srgb(b)
+
+
+def ratio(a: str, b: str) -> float:
+    la, lb = _lum(a), _lum(b)
+    hi, lo = max(la, lb), min(la, lb)
+    return (hi + 0.05) / (lo + 0.05)
+
+
+def darken_to(ink: str, ground: str, target: float) -> str | None:
+    """The nearest darker twin of `ink` that clears `target` on `ground`, hue preserved."""
+    h = ink.lstrip("#")
+    r, g, b = (int(h[i:i + 2], 16) for i in (0, 2, 4))
+    for step in range(100, 14, -1):
+        f = step / 100.0
+        cand = "%02X%02X%02X" % (int(r * f), int(g * f), int(b * f))
+        if ratio(cand, ground) >= target:
+            return cand
+    return None
+
+
+def _norm(s: str) -> str | None:
+    s = s.strip().lstrip("#").upper()
+    return s if re.fullmatch(r"[0-9A-F]{6}", s) else None
+
+
+def from_style(path: Path) -> tuple[list[str], list[str]]:
+    """Every 6-hex colour constant in a style module, in declaration order.
+
+    Grounds are guessed as the lightest third (a canvas/tint is what text sits ON) and inks as
+    everything else — a guess the printed table makes obvious enough to correct by hand.
+    """
+    spec = importlib.util.spec_from_file_location("_style_probe", path)
+    if not spec or not spec.loader:
+        raise RuntimeError(f"cannot import {path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_style_probe"] = mod
+    spec.loader.exec_module(mod)
+
+    seen: dict[str, str] = {}
+    for name in dir(mod):
+        if name.startswith("_"):
+            continue
+        val = getattr(mod, name)
+        for cand in ([val] if isinstance(val, str) else
+                     list(val) if isinstance(val, (list, tuple)) else []):
+            if isinstance(cand, str) and (hx := _norm(cand)):
+                seen.setdefault(hx, name)
+        if val.__class__.__name__ == "RGBColor":
+            if hx := _norm(str(val)):
+                seen.setdefault(hx, name)
+    hexes = list(seen)
+    if not hexes:
+        raise RuntimeError(f"no colour constants found in {path}")
+    light = sorted(hexes, key=_lum, reverse=True)
+    n_ground = max(1, len(light) // 3)
+    return [h for h in hexes if h not in light[:n_ground]], light[:n_ground]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--inks", help="comma-separated hex colours used as TEXT or as MARKS")
+    ap.add_argument("--grounds", help="comma-separated hex colours text SITS ON")
+    ap.add_argument("--from-style", dest="style", help="a deck style.py to read tokens from")
+    a = ap.parse_args()
+
+    if a.style:
+        try:
+            inks, grounds = from_style(Path(a.style).expanduser())
+        except Exception as e:
+            print(f"NOT CHECKED — {e}", file=sys.stderr)
+            return 2
+        print(f"tokens read from {a.style}\n")
+    elif a.inks and a.grounds:
+        inks = [h for t in a.inks.split(",") if (h := _norm(t))]
+        grounds = [h for t in a.grounds.split(",") if (h := _norm(t))]
+    else:
+        ap.error("give --inks and --grounds, or --from-style")
+
+    w = max(len(g) for g in grounds) + 2
+    print("contrast matrix — ink (rows) on ground (columns)")
+    print("  " + " " * 10 + "".join(f"{g:>{w}}" for g in grounds))
+    for ink in inks:
+        cells = []
+        for g in grounds:
+            r = ratio(ink, g)
+            flag = " " if r >= BODY else ("*" if r >= LARGE else "!")
+            cells.append(f"{r:>{w - 1}.2f}{flag}")
+        print(f"  {ink:<10}" + "".join(cells))
+    print("\n  blank = clears 4.5 (body text) · * = 3.0-4.5 (large/bold or a MARK only)"
+          "\n  !     = under 3.0 — unusable as text or as a mark on that ground")
+
+    print("\nresolved tokens — use the FILL value for shapes, the TEXT value for any run")
+    unusable = 0
+    for ink in inks:
+        worst_g = min(grounds, key=lambda g: ratio(ink, g))
+        r = ratio(ink, worst_g)
+        if r >= BODY:
+            print(f"  {ink}  FILL + TEXT anywhere        (worst pair {r:.2f} on {worst_g})")
+            continue
+        fixes = []
+        for g in grounds:
+            if ratio(ink, g) < BODY:
+                tw = darken_to(ink, g, BODY)
+                fixes.append(f"on {g} -> {tw} ({ratio(tw, g):.2f})" if tw else f"on {g} -> none")
+        ok_as_mark = all(ratio(ink, g) >= MARK for g in grounds)
+        role = "FILL only" + ("" if ok_as_mark else "; NOT even a mark on every ground")
+        if not ok_as_mark:
+            unusable += 1
+        print(f"  {ink}  {role}")
+        for f in fixes:
+            print(f"      TEXT twin {f}")
+    if unusable:
+        print(f"\n{unusable} token(s) fall under 3.0 somewhere they are used — pick a different "
+              f"ground for them, or a different hue.")
+        return 1
+    print("\nevery token has a stated role. Paste the FILL/TEXT split into the design plan.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/slide-maker/scripts/preflight_check.py
+++ b/skills/slide-maker/scripts/preflight_check.py
@@ -217,6 +217,146 @@ JUDGMENT = {
 }
 
 
+# ── Three shipped-text defects that are decidable from the built file, and each of which cost
+#    a full render→critic round before this existed. They are grouped apart from the twelve
+#    because they are not PRE-FLIGHT items; they are the mechanical residue the render loop was
+#    being used to discover instead of confirm.
+
+MONO_FACES = ("menlo", "consolas", "courier", "monaco", "sf mono", "dejavu sans mono")
+FULLWIDTH_CLOSERS = "。，、；：！？）》」』】"
+# a HALF-WIDTH Latin/digit glyph immediately followed by a full-width mark: PowerPoint's and
+# LibreOffice's CJK/Latin auto-spacing then opens a gap BEFORE the punctuation, which
+# python-pptx cannot switch off. The only fix is to not write the adjacency.
+# The left class is deliberately ASCII-only — a full-width `）` before `：` is ordinary Chinese
+# punctuation with no script boundary, so including it produced false positives.
+LATIN_THEN_FW = re.compile(rf"([A-Za-z0-9%+\)\]])([{FULLWIDTH_CLOSERS}])")
+
+
+def _paras(slide):
+    """(shape, paragraph_text, max_pt, {font names}) for every non-empty text paragraph."""
+    for sh in slide.shapes:
+        if not sh.has_text_frame:
+            continue
+        for p in sh.text_frame.paragraphs:
+            txt = "".join(r.text for r in p.runs)
+            if not txt.strip():
+                continue
+            sizes = [r.font.size.pt for r in p.runs if r.font.size is not None]
+            fonts = {(r.font.name or "").lower() for r in p.runs if r.font.name}
+            yield sh, txt, (max(sizes) if sizes else None), fonts
+
+
+def _inner_width_in(sh) -> float:
+    tf = sh.text_frame
+    ml = (tf.margin_left or 0) / 914400
+    mr = (tf.margin_right or 0) / 914400
+    return sh.width / 914400 - ml - mr
+
+
+def _face_installed(name: str) -> bool:
+    """Is this font actually on this machine? Cheap, no matplotlib import."""
+    import glob
+    import os
+    stem = re.sub(r"[^a-z0-9]", "", name.lower())
+    if not stem:
+        return False
+    for d in ("/System/Library/Fonts", "/System/Library/Fonts/Supplemental", "/Library/Fonts",
+              os.path.expanduser("~/Library/Fonts"), "/usr/share/fonts", "/usr/local/share/fonts"):
+        for p in glob.glob(os.path.join(d, "**", "*"), recursive=True):
+            if stem in re.sub(r"[^a-z0-9]", "", os.path.basename(p).lower()):
+                return True
+    return False
+
+
+def check_mono_wrap(prs):
+    """A broken command line is not a cosmetic defect — it is a WRONG command.
+
+    Measured: a deck shipped `npx skills add addsumtech/slides_maker` in a code panel. In the
+    render it came out as three lines, and the visible text copied as
+    `…/slides_maker/slide-maker` — a repo path that 404s. The one line a persuaded reader must
+    transcribe correctly was the broken one, and nothing flagged it: `code_block` sets
+    word_wrap=False, so a too-long line OVERFLOWS its panel instead of wrapping, and an
+    overflow inside a panel is invisible to every geometry check.
+
+    Two things make this checkable, and the second is the one that actually bit:
+      1. width — monospace is fixed-advance, so `chars x advance x pt` against the box's own
+         inner width is exact. 0.62em is used deliberately: at or above every common mono face,
+         so the check errs toward warning early.
+      2. SUBSTITUTION — deckkit's default MONO is 'Consolas', a Windows face absent from macOS
+         and most Linux boxes. When it is missing the renderer picks something wider, so a line
+         that fits nominally still breaks. The historical failure fit with ~10% margin and
+         broke anyway. A line inside 15% of its box is therefore reported as tight, and a
+         missing mono face is reported outright.
+    """
+    over, tight, missing = [], [], set()
+    for i, s in enumerate(prs.slides, 1):
+        for sh, txt, pt, fonts in _paras(s):
+            mono = [f for f in fonts if any(m in f for m in MONO_FACES)]
+            if not pt or not mono:
+                continue
+            for f in mono:
+                if not _face_installed(f):
+                    missing.add(f)
+            avail = _inner_width_in(sh)
+            need = len(txt) * 0.62 * pt / 72.0
+            if need > avail:
+                over.append(f"s{i} needs {need:.2f}in in {avail:.2f}in: {txt[:40]!r}")
+            elif need > 0.85 * avail:
+                tight.append(f"s{i} {need:.2f}/{avail:.2f}in ({need/avail:.0%}): {txt[:40]!r}")
+    if over:
+        return "FAIL", (f"{len(over)} mono line(s) overflow their panel (word_wrap is off, so "
+                        f"they run off it silently) — " + " · ".join(over[:3]))
+    if missing:
+        return "FAIL", (f"mono face not installed: {', '.join(sorted(missing))} — the renderer "
+                        f"substitutes a different width, so the panel you checked is not the "
+                        f"panel a reader sees. Set deckkit.MONO to an installed face.")
+    if tight:
+        return "ADVISORY", (f"{len(tight)} mono line(s) fill >85% of the panel — a substituted "
+                            f"face will break them; drop a point or widen — " + " · ".join(tight[:2]))
+    return "PASS", "every monospace line fits its panel with margin, in an installed face"
+
+
+def check_latin_fullwidth(prs):
+    """A space appears BEFORE full-width punctuation that follows a Latin run.
+
+    Shipped on 5 of 12 slides in a real deck and found only by a human at 5x zoom: `原生 PPTX 。`,
+    `既搭 deck 、又给它打分`, `（第 3 、 5 步）`. The renderer's CJK/Latin auto-spacer inserts the gap
+    and python-pptx has no switch for it, so the adjacency itself is the defect — reword so a
+    CJK glyph precedes the mark, or drop the mark.
+    """
+    bad = []
+    for i, s in enumerate(prs.slides, 1):
+        for _sh, txt, _pt, _f in _paras(s):
+            for m in LATIN_THEN_FW.finditer(txt):
+                bad.append(f"s{i} '…{m.group(1)}{m.group(2)}…' in {txt[:30]!r}")
+    if bad:
+        return "FAIL", f"{len(bad)} Latin→full-width adjacency — " + " · ".join(bad[:3])
+    return "PASS", "no Latin glyph sits immediately before full-width punctuation"
+
+
+def check_box_geometry(prs):
+    """A text box with no usable interior — the silent class.
+
+    `h = card_h - 1.42` with card_h = 1.30 yields -0.12; python-pptx stores it, the run
+    overflows a box that has no inside, and every geometry check stays green because there is
+    nothing to overlap. deckkit.text() now raises on this at the call site; this catches decks
+    built by other means, and boxes too short to hold one line of their own type.
+    """
+    hard, soft = [], []
+    for i, s in enumerate(prs.slides, 1):
+        for sh, txt, pt, _f in _paras(s):
+            h = sh.height / 914400
+            if h <= 0 or sh.width / 914400 <= 0:
+                hard.append(f"s{i} {sh.width/914400:.2f}x{h:.2f}in {txt[:24]!r}")
+            elif pt and h < 0.60 * pt / 72.0:
+                soft.append(f"s{i} {h:.2f}in box for {pt:g}pt {txt[:24]!r}")
+    if hard:
+        return "FAIL", f"{len(hard)} non-positive text box(es) — " + " · ".join(hard[:3])
+    if soft:
+        return "ADVISORY", f"{len(soft)} box under half a line tall — " + " · ".join(soft[:2])
+    return "PASS", "every text box has a usable interior"
+
+
 def main() -> int:
     ap = argparse.ArgumentParser()
     ap.add_argument("deck")
@@ -245,6 +385,12 @@ def main() -> int:
         (10, "Hand-off: fonts",        item10_fonts(prs)),
     ]
 
+    residue = [
+        ("mono wrap",        check_mono_wrap(prs)),
+        ("Latin→full-width", check_latin_fullwidth(prs)),
+        ("box geometry",     check_box_geometry(prs)),
+    ]
+
     print(f"PRE-FLIGHT (mechanical subset) — {deck.name}")
     fails = 0
     for n, name, (status, detail) in checks:
@@ -252,6 +398,13 @@ def main() -> int:
         if status == "FAIL":
             fails += 1
         print(f"  {mark} {n:>2}. {name:<22} {detail}")
+
+    print("\n  shipped-text residue (decidable here; each of these used to cost a render round):")
+    for name, (status, detail) in residue:
+        mark = {"PASS": "✓", "FAIL": "✗", "ADVISORY": "!", "NOT CHECKABLE": "—"}[status]
+        if status == "FAIL":
+            fails += 1
+        print(f"  {mark}  ·  {name:<22} {detail}")
 
     print("\n  ( ! = advisory: real but undecidable from the file alone — read it, do not ignore it )")
     print("\n  NOT CHECKABLE BY ANY PROGRAM — these stay YOUR ticks, and this tool")


### PR DESCRIPTION
Three defect classes that were decidable from the built file, but were being
discovered a render round later — by a linter, a critic, or a human at 5x zoom.

## What changed

**`deckkit.text()` raises on a non-positive box.** `h = card_h - 1.42` with
`card_h = 1.30` gives `-0.12`. python-pptx accepted it, the run overflowed a box
with no interior, and every geometry check stayed green because there was nothing
to overlap. It shipped a tier card whose body text spilled through the rule below
it. The traceback now names the slide function, where the bad arithmetic lives.

**`preflight_check.py` gains three checks**, grouped apart from the twelve
because they are not PRE-FLIGHT items — they are the mechanical residue the
render loop was absorbing:

| check | catches |
|---|---|
| `mono wrap` | A wrapped command is a **wrong** command. A deck shipped `npx skills add addsumtech/slides_maker` in a code panel; it rendered as three lines and copied as a path that 404s. `code_block` sets `word_wrap=False`, so a long line overflows its panel *silently*. The root cause was **substitution** — deckkit's default `MONO` is Consolas, absent from macOS, so the renderer picks something wider and a line that fits nominally still breaks. Reports overflow, a missing mono face, and any line inside 15% of its box. |
| `Latin→full-width` | The renderer opens a gap **before** a full-width mark that follows a Latin glyph (`原生 PPTX 。`), and python-pptx cannot switch it off. Shipped on 5 of 12 slides; found only at 5x zoom. |
| `box geometry` | Non-positive or under-half-a-line text boxes, for decks not built through `deckkit.text()`. |

**`palette_audit.py`** (new) resolves a palette into FILL-only vs TEXT-safe
tokens once, before the build, and hands back a darkened twin per ground.
SKILL.md already states the two-token rule; it is still easy to break because
the check is per-*pair* and a build touches dozens. On one deck the author
declared the rule in the design plan and then broke it four times — each in a
pair they weren't thinking about while computing contrast for a different pair.
Run against that deck's original palette, the matrix flags all four up front:

```
D18A2E  FILL only; NOT even a mark on every ground   <- tier stripe at 2.25:1
E2543A  FILL only  -> TEXT twin on FBE3DC -> B4432E  <- coral text at 3.08:1
7A7364  FILL only  -> TEXT twin on FAF3E4 -> 766F61  <- muted text at 4.26:1
1F5F63 / 20304A  FILL + TEXT anywhere
```

Supports `--from-style path/to/style.py` to read a deck's own tokens.

## Why scripts and not prose

Every one of these rules already exists in SKILL.md and was read. They were
still broken, because the rule is prose and the mistake is silent: nothing
reported it. Per the layering principle — anything a program can decide belongs
in `scripts/`, and a lint that fails outranks a paragraph that asks nicely — so
no SKILL.md change was needed. The new checks hang off `preflight_check.py`,
which SKILL.md already requires before the first render, so they inherit a live
backstop rather than adding another self-attested tick.

## Verification

- **42 tests pass** across the suite — 13 in `test_preflight_check.py` (the file
  modified), 22 `test_lint_regressions.py` incl. the renderer-measurement
  calibration, 7 `test_critic_waiver_gate.py`, plus both Codex gate tests.
- `check_reference_code.py` clean: 41 markdown files, 29 deckkit calls resolve.
- `smoke_component_audit` and `smoke_render_slides`: 0 failures.
- The new checks **reproduce every historical defect** listed above, and found
  **4 residual ones in a deck already judged clean** (3 punctuation adjacencies
  + a pip line filling 99% of its panel).

## Note for review

`deckkit.text()` now raising is a behaviour change: an existing build script
that passes a degenerate box will fail where it previously produced a silently
broken slide. That is the intent, but it is why this is a PR rather than a push
to `main`.