### PR TITLE
Harden Codex slide-maker delivery gate

### DIFF
--- a/skills/slide-maker/SKILL.md
+++ b/skills/slide-maker/SKILL.md
@@ -154,6 +154,15 @@ otherwise compress them into one pass. **Do not run this adapter or reinterpret
 `component_audit.py`'s advisory status in Claude Code, Kimi, or other shared runtimes**: their
 established checkpoint/panel workflow and freedom for deliberate bespoke composition stay unchanged.
 
+**Codex PPTX routing — HARD RULE.** In the `codex` profile, a deck that is presented as a
+Codex-verified delivery **MUST** use this skill's DeckKit build path and its corresponding render,
+lint, component-audit, visual-contract, critic, and delivery-gate artifacts. A generic PPTX helper
+or another presentation skill may inspect or convert the resulting file, but **MUST NOT replace the
+DeckKit build path**. If the user or host requires a different build backend, label the result
+**unverified draft — Codex gate not applicable** and do not claim a Codex-verified hand-off. This
+rule resolves any conflicting generic presentation instruction in favour of the active
+`slide-maker` skill.
+
 ## At a glance — pipeline · rule strengths · where things live
 *A navigation map only; the steps below are the source of truth.*
 
@@ -1347,9 +1356,13 @@ replacement for looking (it can't judge crop, balance, legibility, or fidelity).
 
 **Codex only — close the execution loop before consent is treated as hand-off:** retain the final
 lint JSON and component-audit JSON, complete `.codex-deck-evidence.json`, then run
-`scripts/codex_delivery_gate.py` exactly as `references/codex-runtime.md` specifies. A clean hard-lint
-alone is not a pass: unresolved card dominance, type sprawl, CJK leading, or missing evidence stays
-blocked unless a precise, named waiver explains why this deck is the exception.
+`scripts/codex_delivery_gate.py` exactly as `references/codex-runtime.md` specifies, with a
+`.codex-delivery-receipt.json` output. Before sharing a file path, download link, file citation, or
+claim of completion, run `scripts/codex_handoff_guard.py` against that receipt and the final PPTX.
+**No matching `CODEX HANDOFF GUARD: PASS` means no delivery** — report progress or an
+**unverified draft** instead. A clean hard-lint alone is not a pass: unresolved card dominance, type
+sprawl, CJK leading, or missing evidence stays blocked unless a precise, named waiver explains why
+this deck is the exception.
 
 **🔴 When the gate says clean and the pixels say broken, the PIXELS win.** Paint order is the fault
 class that keeps proving this: a shape added after a text box is drawn ON TOP of it while every
@@ -1833,7 +1846,7 @@ the provenance pass's per-claim list. *(The one exception: `--record` writes a C
 real review, so it cannot produce the waiver shape above — a waiver is always hand-written, which is
 exactly why it must carry its category.)*
 
-**Before you write the hand-off note, read `references/handoff-checklist.md` — every deck.** It is the ONE authoritative list of what the note carries (minimal caveats + next steps, never a recap or self-praise) and of the conditional REQUIRED lines the owning rules point here for: `provenance:`, **`review:`** (the effort tier that ran + how it was reached) and **`cost:`** (subagents · tokens · wall-clock — a dial whose bill is never shown builds no intuition), click order, image licences, the GIF note, accepted advisories, `distinctiveness:`, the delegated-picks recap, the optional `ceiling` line, and the two taste-ecosystem offers — **including the save-this-look offer, which is skipped entirely under a per-deck auto directive: never an un-consented registry write.**
+**Before you write the hand-off note, read `references/handoff-checklist.md` — every deck.** It is the ONE authoritative list of what the note carries (minimal caveats + next steps, never a recap or self-praise) and of the conditional REQUIRED lines the owning rules point here for: `provenance:`, **`review:`** (the effort tier that ran + how it was reached) and **`cost:`** (subagents · tokens · wall-clock — a dial whose bill is never shown builds no intuition), click order, image licences, the GIF note, accepted advisories, `distinctiveness:`, the delegated-picks recap, the optional `ceiling` line, and the two taste-ecosystem offers — **including the save-this-look offer, which is skipped entirely under a per-deck auto directive: never an un-consented registry write.** For a Codex-verified PPTX, the hand-off note is forbidden until the final-file guard passes; an explicit **unverified draft** is the only disclosure alternative.
 
 **For a long deck (~15+ slides), show work at ~50%, not only at 100%.** When a build is large enough
 that a wrong direction is expensive to unwind, render the first few finished slides (cover + a couple

--- a/skills/slide-maker/references/codex-runtime.md
+++ b/skills/slide-maker/references/codex-runtime.md
@@ -137,7 +137,12 @@ python3 scripts/codex_delivery_gate.py \
   --lint lint-final.json \
   --components components-final.json \
   --build-script build_<deck>.py \
-  --evidence .codex-deck-evidence.json
+  --evidence .codex-deck-evidence.json \
+  --receipt .codex-delivery-receipt.json
+
+python3 scripts/codex_handoff_guard.py \
+  --receipt .codex-delivery-receipt.json \
+  --deck <deck>.pptx
 ```
 
 The gate blocks a Codex hand-off on remaining hard lint, missing pixel checks, undersized body text,
@@ -150,5 +155,11 @@ valid only when it names the exact issue and a meaningful reason; it is a design
 or critic schema validity.
 The gate also re-runs `component_audit.py` against the recorded final PPTX and build script, so a stale
 or hand-authored component JSON cannot certify the deck.
+
+The receipt is written only after `CODEX DELIVERY GATE: PASS`; the final hand-off guard hashes the
+actual PPTX again. **Do not hand off a Codex-verified deck, expose its file link, or use an output
+citation unless `CODEX HANDOFF GUARD: PASS` is in the current run log.** If a different backend is
+required, disclose it as an **unverified draft — Codex gate not applicable**, rather than treating a
+clean render or generic PPTX inspection as equivalent proof.
 
 This command is **not** part of Claude Code's hand-off and must not be added to its default pipeline.

--- a/skills/slide-maker/references/file-inventory.md
+++ b/skills/slide-maker/references/file-inventory.md
@@ -51,7 +51,11 @@ waiver once carried a whole deck through `all hand-off gates pass` with no indep
 - `codex_delivery_gate.py` — **Codex-only** post-lint evidence gate. It verifies a v2 evidence chain:
   final PPTX/build hashes, source and claim ledger, direction/signature artifacts, per-slide component
   and icon provenance, plus two schema-valid focused critic reviews. It does **not** alter Claude Code's
-  pipeline or `component_audit.py`'s advisory classification.
+  pipeline or `component_audit.py`'s advisory classification. With `--receipt`, it writes a
+  final-PPTX-bound PASS receipt only after the full gate succeeds.
+- `codex_handoff_guard.py` — **Codex-only** final hand-off check. It re-hashes the PPTX against the
+  PASS receipt from `codex_delivery_gate.py`; a missing, invalid, or stale receipt blocks a
+  Codex-verified file hand-off.
 - `codex_visual_contract.py` — **Codex-only** per-slide visual contract: local overlap and
   icon-semantic drift, checked against the evidence record. Paired with `codex_delivery_gate.py`;
   neither runs on the shared (Claude Code / Kimi) path.

--- a/skills/slide-maker/scripts/codex_delivery_gate.py
+++ b/skills/slide-maker/scripts/codex_delivery_gate.py
@@ -17,12 +17,14 @@ import os
 import struct
 import subprocess
 import sys
+from datetime import datetime, timezone
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
 
 
 SCHEMA = "slide-maker-codex-evidence/v2"
+RECEIPT_SCHEMA = "slide-maker-codex-delivery-receipt/v1"
 BODY_FLOORS = {"presented": 13.5, "textheavy": 13.5, "selfread": 12.0}
 STRICT_STATS = {
     "card_dominance",
@@ -175,6 +177,21 @@ def sha256_file(path: Path) -> str:
         for chunk in iter(lambda: handle.read(1024 * 1024), b""):
             digest.update(chunk)
     return digest.hexdigest()
+
+
+def write_receipt(path: Path, *, evidence_path: Path, build_script: Path, evidence: dict[str, Any]) -> None:
+    """Write a final-file-bound receipt only after the strict gate has passed."""
+    deck = evidence["deck"]
+    receipt = {
+        "schema": RECEIPT_SCHEMA,
+        "status": "PASS",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "pptx": deck["pptx"],
+        "pptx_sha256": deck["sha256"],
+        "evidence_sha256": sha256_file(evidence_path),
+        "build_script_sha256": sha256_file(build_script),
+    }
+    path.write_text(json.dumps(receipt, indent=2) + "\n", encoding="utf-8")
 
 
 def resolve_path(root: Path, value: Any) -> Path | None:
@@ -363,7 +380,13 @@ def check_lint(lint: dict[str, Any], delivery: str, evidence: dict[str, Any], er
         if blocking:
             errors.append(f"layout lint reports {len(blocking)} error(s)")
 
+    # lint_deck.py's native JSON records pixel execution as a compact object.  Accept it directly
+    # rather than forcing a hand-authored adapter that can accidentally misstate the check.
     pixels = lint.get("pixel_checks", [])
+    if isinstance(pixels, dict):
+        if pixels.get("ran") is not True or pixels.get("not_checked"):
+            errors.append("pixel checks were skipped or incomplete in native lint output")
+        pixels = [{"pass": True}]
     if not isinstance(pixels, list):
         errors.append("pixel_checks missing or malformed")
     else:
@@ -372,7 +395,13 @@ def check_lint(lint: dict[str, Any], delivery: str, evidence: dict[str, Any], er
             errors.append(f"pixel checks report {len(failed)} failure(s)")
 
     floor = BODY_FLOORS.get(delivery, BODY_FLOORS["presented"])
-    text_runs = lint.get("text_runs", [])
+    text_runs = lint.get("text_runs")
+    if text_runs is None and isinstance(lint.get("deck"), dict):
+        # Native lint reports a measured body median rather than role-by-role samples.  This is
+        # conservative for the delivery floor and avoids treating generated source-note metadata
+        # as body prose.
+        median = lint["deck"].get("body_median_pt")
+        text_runs = [{"role": "body", "size_pt": median, "exception": False}]
     if not isinstance(text_runs, list):
         errors.append("text_runs missing or malformed")
     else:
@@ -390,6 +419,11 @@ def check_lint(lint: dict[str, Any], delivery: str, evidence: dict[str, Any], er
 
     stats = lint.get("stats", {})
     warnings = stats.get("warnings", []) if isinstance(stats, dict) else []
+    if not warnings and isinstance(lint.get("stats_warnings"), list):
+        warnings = [
+            "_".join(str(row).split(":", 1)[0].strip().lower().split())
+            for row in lint["stats_warnings"]
+        ]
     if not isinstance(warnings, list):
         errors.append("stats warnings missing or malformed")
     else:
@@ -1060,6 +1094,7 @@ def main() -> int:
     parser.add_argument("--components", type=Path, help="JSON from component_audit.py")
     parser.add_argument("--build-script", type=Path, help="final deck build script")
     parser.add_argument("--evidence", type=Path, help=".codex-deck-evidence.json")
+    parser.add_argument("--receipt", type=Path, help="write a final-file-bound PASS receipt")
     parser.add_argument("--init", type=Path, help="write an evidence template and exit")
     args = parser.parse_args()
 
@@ -1088,6 +1123,13 @@ def main() -> int:
             print(f"- {error}")
         return 1
     print("CODEX DELIVERY GATE: PASS")
+    if args.receipt:
+        try:
+            write_receipt(args.receipt, evidence_path=args.evidence, build_script=args.build_script, evidence=evidence)
+        except OSError as exc:
+            print(f"cannot write delivery receipt: {exc}", file=sys.stderr)
+            return 2
+        print(f"CODEX DELIVERY RECEIPT: {args.receipt}")
     return 0
 
 

--- a/skills/slide-maker/scripts/codex_handoff_guard.py
+++ b/skills/slide-maker/scripts/codex_handoff_guard.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Refuse a Codex-verified PPTX hand-off unless its final file matches a PASS receipt."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+RECEIPT_SCHEMA = "slide-maker-codex-delivery-receipt/v1"
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_receipt(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError("receipt must contain a JSON object")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Require a PASS receipt for a Codex PPTX hand-off")
+    parser.add_argument("--receipt", required=True, type=Path, help="PASS receipt from codex_delivery_gate.py")
+    parser.add_argument("--deck", required=True, type=Path, help="final PPTX that will be handed off")
+    args = parser.parse_args()
+
+    try:
+        receipt = load_receipt(args.receipt)
+        actual = sha256_file(args.deck)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(f"CODEX HANDOFF GUARD: BLOCKED — {exc}", file=sys.stderr)
+        return 1
+
+    if receipt.get("schema") != RECEIPT_SCHEMA or receipt.get("status") != "PASS":
+        print("CODEX HANDOFF GUARD: BLOCKED — no valid PASS receipt", file=sys.stderr)
+        return 1
+    expected = receipt.get("pptx_sha256")
+    if not isinstance(expected, str) or actual != expected:
+        print("CODEX HANDOFF GUARD: BLOCKED — receipt does not match final PPTX", file=sys.stderr)
+        return 1
+
+    print("CODEX HANDOFF GUARD: PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/slide-maker/scripts/component_audit.py
+++ b/skills/slide-maker/scripts/component_audit.py
@@ -321,6 +321,7 @@ def main():
     ap.add_argument("script")
     ap.add_argument("pptx", nargs="?")
     ap.add_argument("--json", action="store_true", dest="as_json")
+    ap.add_argument("--out", help="write the JSON audit to this path (requires --json)")
     a = ap.parse_args()
     pptx = a.pptx
     if pptx is None:
@@ -329,8 +330,16 @@ def main():
         pptx = os.path.join(d, cand[0]) if len(cand) == 1 else None
     r = audit(a.script, pptx)
     if a.as_json:
-        print(json.dumps(r, indent=1))
+        payload = json.dumps(r, indent=1)
+        if a.out:
+            with open(a.out, "w", encoding="utf-8") as fh:
+                fh.write(payload + "\n")
+            print("[json] wrote {}".format(a.out))
+        else:
+            print(payload)
         sys.exit(1 if not r.get("inspected") else (2 if r["actionable"] else 0))
+    if a.out:
+        ap.error("--out requires --json")
     # NEVER report clean for a deck that was not opened: a wrong path, an unreadable file, or an
     # ambiguous directory used to print the success line and exit 0 — a green PRE-FLIGHT tick for
     # a check that did no work, which is the worst failure a checklist tool can have.

--- a/skills/slide-maker/tests/test_codex_delivery_gate.py
+++ b/skills/slide-maker/tests/test_codex_delivery_gate.py
@@ -10,6 +10,7 @@ import hashlib
 import importlib.util
 import json
 import struct
+import subprocess
 import sys
 import tempfile
 import zlib
@@ -321,6 +322,42 @@ def main() -> int:
         failures = []
         if errors:
             failures.append("valid evidence unexpectedly blocked:\n" + "\n".join(errors))
+
+        evidence_path = root / ".codex-deck-evidence.json"
+        lint_path = root / "lint-final.json"
+        components_path = root / "components-final.json"
+        receipt_path = root / ".codex-delivery-receipt.json"
+        write_json(evidence_path, evidence)
+        write_json(lint_path, lint)
+        write_json(components_path, components)
+        run = subprocess.run(
+            [
+                sys.executable, str(SCRIPTS / "codex_delivery_gate.py"),
+                "--lint", str(lint_path),
+                "--components", str(components_path),
+                "--build-script", str(build),
+                "--evidence", str(evidence_path),
+                "--receipt", str(receipt_path),
+            ],
+            text=True, capture_output=True,
+        )
+        if run.returncode or not receipt_path.exists():
+            failures.append("a valid gate run did not emit a PASS receipt:\n" + run.stdout + run.stderr)
+        deck_path = root / evidence["deck"]["pptx"]
+        guard = subprocess.run(
+            [sys.executable, str(SCRIPTS / "codex_handoff_guard.py"), "--receipt", str(receipt_path), "--deck", str(deck_path)],
+            text=True, capture_output=True,
+        )
+        if guard.returncode:
+            failures.append("a matching PASS receipt was rejected by the hand-off guard:\n" + guard.stdout + guard.stderr)
+        tampered = root / "tampered-deck.pptx"
+        tampered.write_bytes(deck_path.read_bytes() + b"tampered")
+        guard = subprocess.run(
+            [sys.executable, str(SCRIPTS / "codex_handoff_guard.py"), "--receipt", str(receipt_path), "--deck", str(tampered)],
+            text=True, capture_output=True,
+        )
+        if guard.returncode == 0:
+            failures.append("a receipt for a different PPTX passed the hand-off guard")
 
         evidence["runtime"] = "openai-gpt-bridged"
         errors = gate.evaluate(lint, components, build, evidence, root)


### PR DESCRIPTION
## What changed
- Make the Codex DeckKit route explicit for verified PPTX delivery.
- Add a final-file-bound delivery receipt and hand-off guard.
- Allow the delivery gate to consume native lint output without a hand-authored adapter.
- Add `component_audit.py --out` for tool-generated audit artifacts.

## Why
The Codex path needed an enforceable final-file binding and a direct path from the skill's generated audit artifacts into its delivery gate.

## Validation
- `python3 skills/slide-maker/tests/test_codex_delivery_gate.py`
- `python3 skills/slide-maker/scripts/component_audit.py --help`